### PR TITLE
👷chore: update module path for v2

### DIFF
--- a/app/application/jrp/download_usecase.go
+++ b/app/application/jrp/download_usecase.go
@@ -3,8 +3,8 @@ package jrp
 import (
 	"errors"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // downloadUseCase is a struct that contains the use case of the download.

--- a/app/application/jrp/download_usecase_test.go
+++ b/app/application/jrp/download_usecase_test.go
@@ -5,8 +5,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/favorite_usecase.go
+++ b/app/application/jrp/favorite_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // favoriteUseCase is a struct that contains the use case of the favoriting jrp from the table history in jrp sqlite database.

--- a/app/application/jrp/favorite_usecase_test.go
+++ b/app/application/jrp/favorite_usecase_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/generate_jrp_usecase.go
+++ b/app/application/jrp/generate_jrp_usecase.go
@@ -3,8 +3,8 @@ package jrp
 import (
 	"time"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // generateJrpUseCase is a struct that contains the use case of the generation jrp.

--- a/app/application/jrp/generate_jrp_usecase_test.go
+++ b/app/application/jrp/generate_jrp_usecase_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/get_history_usecase.go
+++ b/app/application/jrp/get_history_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // getHistoryUseCase is a struct that contains the use case of the getting jrp from the table history in jrp sqlite database.

--- a/app/application/jrp/get_history_usecase_test.go
+++ b/app/application/jrp/get_history_usecase_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/remove_history_usecase.go
+++ b/app/application/jrp/remove_history_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // removeHistoryUseCase is a struct that contains the use case of the removing jrp from the table history in jrp sqlite database.

--- a/app/application/jrp/remove_history_usecase_test.go
+++ b/app/application/jrp/remove_history_usecase_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 	"go.uber.org/mock/gomock"
 )
 

--- a/app/application/jrp/save_history_usecase.go
+++ b/app/application/jrp/save_history_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // saveHistoryUseCase is a struct that contains the use case of the saving jrp to the table history in jrp sqlite database.

--- a/app/application/jrp/save_history_usecase_test.go
+++ b/app/application/jrp/save_history_usecase_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/search_history_usecase.go
+++ b/app/application/jrp/search_history_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // searchHistoryUseCase is a struct that contains the use case of the searching jrp from the table history in jrp sqlite database.

--- a/app/application/jrp/search_history_usecase_test.go
+++ b/app/application/jrp/search_history_usecase_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/application/jrp/unfavorite_usecase.go
+++ b/app/application/jrp/unfavorite_usecase.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 )
 
 // unfavoriteUseCase is a struct that contains the use case of the unfavoriting jrp from the table history in jrp sqlite database.

--- a/app/application/jrp/unfavorite_usecase_test.go
+++ b/app/application/jrp/unfavorite_usecase_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -1,10 +1,10 @@
 package config
 
 import (
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // Configurator is an interface that gets the configuration.

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -4,8 +4,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 func TestNewConfigurator(t *testing.T) {

--- a/app/infrastructure/database/connection.go
+++ b/app/infrastructure/database/connection.go
@@ -3,7 +3,7 @@ package database
 import (
 	"sync"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // DBConnection is an interface that contains the database connection.

--- a/app/infrastructure/database/connection_manager.go
+++ b/app/infrastructure/database/connection_manager.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 var (

--- a/app/infrastructure/database/connection_manager_test.go
+++ b/app/infrastructure/database/connection_manager_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 	"go.uber.org/mock/gomock"
 )
 

--- a/app/infrastructure/database/connection_mock.go
+++ b/app/infrastructure/database/connection_mock.go
@@ -12,7 +12,7 @@ package database
 import (
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/app/infrastructure/database/connection_test.go
+++ b/app/infrastructure/database/connection_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/infrastructure/jrp/repository/history_repository.go
+++ b/app/infrastructure/jrp/repository/history_repository.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // HistoryRepository is a struct that implements the HistoryRepository interface.

--- a/app/infrastructure/jrp/repository/history_repository_test.go
+++ b/app/infrastructure/jrp/repository/history_repository_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/infrastructure/wnjpn/query_service/word_query_service.go
+++ b/app/infrastructure/wnjpn/query_service/word_query_service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 )
 
 // WordQueryService is a struct that implements the WordQueryService interface.

--- a/app/infrastructure/wnjpn/query_service/word_query_service_test.go
+++ b/app/infrastructure/wnjpn/query_service/word_query_service_test.go
@@ -8,11 +8,11 @@ import (
 	"reflect"
 	"testing"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	wnjpnApp "github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	wnjpnApp "github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/command.go
+++ b/app/presentation/cli/jrp/command/command.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"os"
 
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/config"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/config"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/jrp/command/command_mock.go
+++ b/app/presentation/cli/jrp/command/command_mock.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
-	utility "github.com/yanosea/jrp/pkg/utility"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
+	utility "github.com/yanosea/jrp/v2/pkg/utility"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/app/presentation/cli/jrp/command/command_test.go
+++ b/app/presentation/cli/jrp/command/command_test.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/fatih/color"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 	"go.uber.org/mock/gomock"
 )
 

--- a/app/presentation/cli/jrp/command/jrp/completion/bash.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/bash.go
@@ -5,7 +5,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewCompletionBashCommand returns a new instance of the completion bash command.

--- a/app/presentation/cli/jrp/command/jrp/completion/bash_test.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/bash_test.go
@@ -6,7 +6,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewCompletionBashCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/completion/completion.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/completion.go
@@ -1,7 +1,7 @@
 package completion
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewCompletionCommand returns a new instance of the completion command.

--- a/app/presentation/cli/jrp/command/jrp/completion/completion_test.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/completion_test.go
@@ -3,7 +3,7 @@ package completion
 import (
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewCompletionCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/completion/fish.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/fish.go
@@ -5,7 +5,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewCompletionFishCommand returns a new instance of the completion fish command.

--- a/app/presentation/cli/jrp/command/jrp/completion/fish_test.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/fish_test.go
@@ -6,7 +6,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewCompletionFishCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/completion/powershell.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/powershell.go
@@ -5,7 +5,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewCompletionPowerShellCommand returns a new instance of the completion powershell command.

--- a/app/presentation/cli/jrp/command/jrp/completion/powershell_test.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/powershell_test.go
@@ -6,7 +6,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewCompletionPowerShellCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/completion/zsh.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/zsh.go
@@ -5,7 +5,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewCompletionZshCommand returns a new instance of the completion zsh command.

--- a/app/presentation/cli/jrp/command/jrp/completion/zsh_test.go
+++ b/app/presentation/cli/jrp/command/jrp/completion/zsh_test.go
@@ -6,7 +6,7 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewCompletionZshCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/download.go
+++ b/app/presentation/cli/jrp/command/jrp/download.go
@@ -3,13 +3,13 @@ package jrp
 import (
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/config"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/config"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // NewDownloadCommand returns a new instance of the download command.

--- a/app/presentation/cli/jrp/command/jrp/download_test.go
+++ b/app/presentation/cli/jrp/command/jrp/download_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/fatih/color"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	baseConfig "github.com/yanosea/jrp/app/config"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/config"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	baseConfig "github.com/yanosea/jrp/v2/app/config"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/config"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/favorite.go
+++ b/app/presentation/cli/jrp/command/jrp/favorite.go
@@ -5,12 +5,12 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // FavoriteOptions provides the options for the favorite command.

--- a/app/presentation/cli/jrp/command/jrp/favorite_test.go
+++ b/app/presentation/cli/jrp/command/jrp/favorite_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/generate/generate.go
+++ b/app/presentation/cli/jrp/command/jrp/generate/generate.go
@@ -5,14 +5,14 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	wnjpnApp "github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/infrastructure/wnjpn/query_service"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	wnjpnApp "github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/infrastructure/wnjpn/query_service"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // GenerateOptions provides the options for the generate command.

--- a/app/presentation/cli/jrp/command/jrp/generate/generate_test.go
+++ b/app/presentation/cli/jrp/command/jrp/generate/generate_test.go
@@ -9,13 +9,13 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	wnjpnApp "github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	wnjpnApp "github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/generate/interactive.go
+++ b/app/presentation/cli/jrp/command/jrp/generate/interactive.go
@@ -6,15 +6,15 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	wnjpnApp "github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/infrastructure/wnjpn/query_service"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	wnjpnApp "github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/infrastructure/wnjpn/query_service"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // InteractiveOptions provides the options for the interactive command.

--- a/app/presentation/cli/jrp/command/jrp/generate/interactive_test.go
+++ b/app/presentation/cli/jrp/command/jrp/generate/interactive_test.go
@@ -9,13 +9,13 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	wnjpnApp "github.com/yanosea/jrp/app/application/wnjpn"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	wnjpnApp "github.com/yanosea/jrp/v2/app/application/wnjpn"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/history/clear.go
+++ b/app/presentation/cli/jrp/command/jrp/history/clear.go
@@ -3,12 +3,12 @@ package history
 import (
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // ClearOptions provides the options for the clear command.

--- a/app/presentation/cli/jrp/command/jrp/history/clear_test.go
+++ b/app/presentation/cli/jrp/command/jrp/history/clear_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/history/history.go
+++ b/app/presentation/cli/jrp/command/jrp/history/history.go
@@ -3,7 +3,7 @@ package history
 import (
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // HistoryOptions provides the options for the generate command.

--- a/app/presentation/cli/jrp/command/jrp/history/history_test.go
+++ b/app/presentation/cli/jrp/command/jrp/history/history_test.go
@@ -10,12 +10,12 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/jrp/command/jrp/history/remove.go
+++ b/app/presentation/cli/jrp/command/jrp/history/remove.go
@@ -5,12 +5,12 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // RemoveOptions provides the options for the remove command.

--- a/app/presentation/cli/jrp/command/jrp/history/remove_test.go
+++ b/app/presentation/cli/jrp/command/jrp/history/remove_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/history/search.go
+++ b/app/presentation/cli/jrp/command/jrp/history/search.go
@@ -3,11 +3,11 @@ package history
 import (
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // SearchOptions provides the options for the search command.

--- a/app/presentation/cli/jrp/command/jrp/history/search_test.go
+++ b/app/presentation/cli/jrp/command/jrp/history/search_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 func TestNewSearchCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/history/show.go
+++ b/app/presentation/cli/jrp/command/jrp/history/show.go
@@ -5,11 +5,11 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // ShowOptions provides the options for the show command.

--- a/app/presentation/cli/jrp/command/jrp/history/show_test.go
+++ b/app/presentation/cli/jrp/command/jrp/history/show_test.go
@@ -10,12 +10,12 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 func TestNewShowCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/jrp/unfavorite.go
+++ b/app/presentation/cli/jrp/command/jrp/unfavorite.go
@@ -5,12 +5,12 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // UnfavoriteOptions provides the options for the unfavorite command.

--- a/app/presentation/cli/jrp/command/jrp/unfavorite_test.go
+++ b/app/presentation/cli/jrp/command/jrp/unfavorite_test.go
@@ -11,13 +11,13 @@ import (
 	"github.com/fatih/color"
 	c "github.com/spf13/cobra"
 
-	historyDomain "github.com/yanosea/jrp/app/domain/jrp/history"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/infrastructure/jrp/repository"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/presenter"
+	historyDomain "github.com/yanosea/jrp/v2/app/domain/jrp/history"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/infrastructure/jrp/repository"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/presenter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/command/jrp/version.go
+++ b/app/presentation/cli/jrp/command/jrp/version.go
@@ -3,10 +3,10 @@ package jrp
 import (
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/formatter"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/formatter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 var (

--- a/app/presentation/cli/jrp/command/jrp/version_test.go
+++ b/app/presentation/cli/jrp/command/jrp/version_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewVersionCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/command/root.go
+++ b/app/presentation/cli/jrp/command/root.go
@@ -3,13 +3,13 @@ package command
 import (
 	c "github.com/spf13/cobra"
 
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp/completion"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp/generate"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp/history"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/config"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp/completion"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp/generate"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp/history"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/config"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // RootOptions provides the options for the root command.

--- a/app/presentation/cli/jrp/command/root_test.go
+++ b/app/presentation/cli/jrp/command/root_test.go
@@ -8,14 +8,14 @@ import (
 
 	c "github.com/spf13/cobra"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
-	baseConfig "github.com/yanosea/jrp/app/config"
-	"github.com/yanosea/jrp/app/infrastructure/database"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command/jrp/generate"
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/config"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
+	baseConfig "github.com/yanosea/jrp/v2/app/config"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command/jrp/generate"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/config"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewRootCommand(t *testing.T) {

--- a/app/presentation/cli/jrp/config/config.go
+++ b/app/presentation/cli/jrp/config/config.go
@@ -4,11 +4,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	baseConfig "github.com/yanosea/jrp/app/config"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	baseConfig "github.com/yanosea/jrp/v2/app/config"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // JrpCliConfigurator is an interface that gets the configuration of the Jrp cli application.

--- a/app/presentation/cli/jrp/config/config_test.go
+++ b/app/presentation/cli/jrp/config/config_test.go
@@ -5,11 +5,11 @@ import (
 	"reflect"
 	"testing"
 
-	baseConfig "github.com/yanosea/jrp/app/config"
-	"github.com/yanosea/jrp/app/infrastructure/database"
+	baseConfig "github.com/yanosea/jrp/v2/app/config"
+	"github.com/yanosea/jrp/v2/app/infrastructure/database"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/formatter/plain.go
+++ b/app/presentation/cli/jrp/formatter/plain.go
@@ -3,7 +3,7 @@ package formatter
 import (
 	"fmt"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
 )
 
 // PlainFormatter is a struct that formats the output of jrp cli.

--- a/app/presentation/cli/jrp/formatter/plain_test.go
+++ b/app/presentation/cli/jrp/formatter/plain_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
 )
 
 func TestNewPlainFormatter(t *testing.T) {

--- a/app/presentation/cli/jrp/formatter/table.go
+++ b/app/presentation/cli/jrp/formatter/table.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"time"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // TableFormatter is a struct that formats the output of jrp cli.

--- a/app/presentation/cli/jrp/formatter/table_test.go
+++ b/app/presentation/cli/jrp/formatter/table_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
-	jrpApp "github.com/yanosea/jrp/app/application/jrp"
+	jrpApp "github.com/yanosea/jrp/v2/app/application/jrp"
 
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 func TestNewTableFormatter(t *testing.T) {

--- a/app/presentation/cli/jrp/main.go
+++ b/app/presentation/cli/jrp/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"os"
 
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 // JrpCliParams is a struct that represents the options of jrp cli.

--- a/app/presentation/cli/jrp/main_test.go
+++ b/app/presentation/cli/jrp/main_test.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/yanosea/jrp/app/presentation/cli/jrp/command"
+	"github.com/yanosea/jrp/v2/app/presentation/cli/jrp/command"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/presenter/keyboard.go
+++ b/app/presentation/cli/jrp/presenter/keyboard.go
@@ -1,8 +1,8 @@
 package presenter
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/jrp/presenter/keyboard_test.go
+++ b/app/presentation/cli/jrp/presenter/keyboard_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/eiannone/keyboard"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/presenter/presenter_test.go
+++ b/app/presentation/cli/jrp/presenter/presenter_test.go
@@ -4,8 +4,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 func TestPrint(t *testing.T) {

--- a/app/presentation/cli/jrp/presenter/prompt.go
+++ b/app/presentation/cli/jrp/presenter/prompt.go
@@ -1,8 +1,8 @@
 package presenter
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/jrp/presenter/prompt_test.go
+++ b/app/presentation/cli/jrp/presenter/prompt_test.go
@@ -3,8 +3,8 @@ package presenter
 import (
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/app/presentation/cli/jrp/presenter/spinner.go
+++ b/app/presentation/cli/jrp/presenter/spinner.go
@@ -1,8 +1,8 @@
 package presenter
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 )
 
 var (

--- a/app/presentation/cli/jrp/presenter/spinner_test.go
+++ b/app/presentation/cli/jrp/presenter/spinner_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
-	"github.com/yanosea/jrp/pkg/utility"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/utility"
 
 	"go.uber.org/mock/gomock"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yanosea/jrp
+module github.com/yanosea/jrp/v2
 
 go 1.23
 

--- a/pkg/utility/capture.go
+++ b/pkg/utility/capture.go
@@ -3,7 +3,7 @@ package utility
 import (
 	"os"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // Capturer is an interface that captures the output of a function.

--- a/pkg/utility/capture_test.go
+++ b/pkg/utility/capture_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/download_util.go
+++ b/pkg/utility/download_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // DownloadUtil is an interface that contains the utility functions for downloading files.

--- a/pkg/utility/download_util_mock.go
+++ b/pkg/utility/download_util_mock.go
@@ -12,7 +12,7 @@ package utility
 import (
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/pkg/utility/download_util_test.go
+++ b/pkg/utility/download_util_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/file_util.go
+++ b/pkg/utility/file_util.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // FileUtil is an interface that contains the utility functions for file operations.

--- a/pkg/utility/file_util_test.go
+++ b/pkg/utility/file_util_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 	"go.uber.org/mock/gomock"
 )
 

--- a/pkg/utility/keyboard_util.go
+++ b/pkg/utility/keyboard_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // KeyboardUtil provides the utility for the keyboard.

--- a/pkg/utility/keyboard_util_test.go
+++ b/pkg/utility/keyboard_util_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/eiannone/keyboard"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/prompt_util.go
+++ b/pkg/utility/prompt_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 type PromptUtil interface {

--- a/pkg/utility/prompt_util_mock.go
+++ b/pkg/utility/prompt_util_mock.go
@@ -12,7 +12,7 @@ package utility
 import (
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/pkg/utility/prompt_util_test.go
+++ b/pkg/utility/prompt_util_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/rand_util.go
+++ b/pkg/utility/rand_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // RandUtil is an interface that contains the utility functions for generating random numbers.

--- a/pkg/utility/rand_util_test.go
+++ b/pkg/utility/rand_util_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewRandUtil(t *testing.T) {

--- a/pkg/utility/spinner_util.go
+++ b/pkg/utility/spinner_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 type SpinnerUtil interface {

--- a/pkg/utility/spinner_util_mock.go
+++ b/pkg/utility/spinner_util_mock.go
@@ -12,7 +12,7 @@ package utility
 import (
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/pkg/utility/spinner_util_test.go
+++ b/pkg/utility/spinner_util_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )

--- a/pkg/utility/tablewriter_util.go
+++ b/pkg/utility/tablewriter_util.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/olekukonko/tablewriter"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // TableWriterUtil is an interface that contains the utility functions for writing tables.

--- a/pkg/utility/tablewriter_util_mock.go
+++ b/pkg/utility/tablewriter_util_mock.go
@@ -13,7 +13,7 @@ import (
 	io "io"
 	reflect "reflect"
 
-	proxy "github.com/yanosea/jrp/pkg/proxy"
+	proxy "github.com/yanosea/jrp/v2/pkg/proxy"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/pkg/utility/tablewriter_util_test.go
+++ b/pkg/utility/tablewriter_util_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 func TestNewTableWriterUtil(t *testing.T) {

--- a/pkg/utility/version_util.go
+++ b/pkg/utility/version_util.go
@@ -1,7 +1,7 @@
 package utility
 
 import (
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 )
 
 // VersionUtil is an interface that provides the version of the application.

--- a/pkg/utility/version_util_test.go
+++ b/pkg/utility/version_util_test.go
@@ -5,7 +5,7 @@ import (
 	d "runtime/debug"
 	"testing"
 
-	"github.com/yanosea/jrp/pkg/proxy"
+	"github.com/yanosea/jrp/v2/pkg/proxy"
 
 	"go.uber.org/mock/gomock"
 )


### PR DESCRIPTION
- update module path from `github.com/yanosea/jrp` to `github.com/yanosea/jrp/v2`
- this change follows Go modules versioning convention for v2+ modules