### PR TITLE
🚀perf: optimize bulk inserts in history repository

### DIFF
--- a/app/infrastructure/jrp/repository/history_query.go
+++ b/app/infrastructure/jrp/repository/history_query.go
@@ -217,7 +217,7 @@ FROM (
 ORDER BY
   latest_records.ID ASC;
 `
-	// InsertQuery is a query that inserts a record into the history table.
+	// InsertQuery is a query that inserts records into the history table.
 	InsertQuery = `
 INSERT INTO
   history (
@@ -227,14 +227,7 @@ INSERT INTO
     , IsFavorited
     , CreatedAt
     , UpdatedAt
-  ) VALUES (
-    ?
-    , ?
-    , ?
-    , ?
-    , ?
-    , ?
-  );
+  ) VALUES %s;
 `
 	// UpdateIsFavoritedByIdInQuery is a query that updates the is favorited by ID in.
 	UpdateIsFavoritedByIdInQuery = `

--- a/app/infrastructure/jrp/repository/history_repository_test.go
+++ b/app/infrastructure/jrp/repository/history_repository_test.go
@@ -5964,7 +5964,7 @@ func Test_historyRepository_SaveAll(t *testing.T) {
 			cleanup: nil,
 		},
 		{
-			name: "negative testing (db.PrepareContext() failed)",
+			name: "negative testing (tx.ExecContext() failed)",
 			fields: fields{
 				connManager: nil,
 			},
@@ -5992,56 +5992,11 @@ func Test_historyRepository_SaveAll(t *testing.T) {
 			wantErr:  true,
 			setup: func(mockCtrl *gomock.Controller, tt *fields) {
 				mockTx := proxy.NewMockTx(mockCtrl)
+				mockTx.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Tx.ExecContext() failed"))
 				mockTx.EXPECT().Rollback().Return(nil)
 				mockDB := proxy.NewMockDB(mockCtrl)
 				mockDB.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
-				mockDB.EXPECT().PrepareContext(gomock.Any(), gomock.Any()).Return(nil, errors.New("DB.PrepareContext() failed"))
-				mockConnection := database.NewMockDBConnection(mockCtrl)
-				mockConnection.EXPECT().Open().Return(mockDB, nil)
-				mockConnManager := database.NewMockConnectionManager(mockCtrl)
-				mockConnManager.EXPECT().GetConnection(database.JrpDB).Return(mockConnection, nil)
-				tt.connManager = mockConnManager
-			},
-			cleanup: nil,
-		},
-		{
-			name: "negative testing (stmt.ExecContext() failed)",
-			fields: fields{
-				connManager: nil,
-			},
-			args: args{
-				ctx: context.Background(),
-				jrps: []*historyDomain.History{
-					{
-						Phrase: "test",
-						Prefix: sql.NullString{
-							String: "prefix",
-							Valid:  true,
-						},
-						Suffix: sql.NullString{
-							String: "suffix",
-							Valid:  true,
-						},
-						IsFavorited: 0,
-						CreatedAt:   now,
-						UpdatedAt:   now,
-					},
-				},
-			},
-			testData: nil,
-			want:     nil,
-			wantErr:  true,
-			setup: func(mockCtrl *gomock.Controller, tt *fields) {
-				mockStmt := proxy.NewMockStmt(mockCtrl)
-				mockStmt.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("Stmt.ExecContext() failed"))
-				mockStmt.EXPECT().Close().Return(nil)
-				mockTx := proxy.NewMockTx(mockCtrl)
-				mockTx.EXPECT().Rollback().Return(nil)
-				mockDB := proxy.NewMockDB(mockCtrl)
-				mockDB.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
-				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
-				mockDB.EXPECT().PrepareContext(gomock.Any(), gomock.Any()).Return(mockStmt, nil)
 				mockConnection := database.NewMockDBConnection(mockCtrl)
 				mockConnection.EXPECT().Open().Return(mockDB, nil)
 				mockConnManager := database.NewMockConnectionManager(mockCtrl)
@@ -6080,15 +6035,12 @@ func Test_historyRepository_SaveAll(t *testing.T) {
 			setup: func(mockCtrl *gomock.Controller, tt *fields) {
 				mockResult := proxy.NewMockResult(mockCtrl)
 				mockResult.EXPECT().LastInsertId().Return(int64(0), errors.New("Result.LastInsertId() failed"))
-				mockStmt := proxy.NewMockStmt(mockCtrl)
-				mockStmt.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockResult, nil)
-				mockStmt.EXPECT().Close().Return(nil)
 				mockTx := proxy.NewMockTx(mockCtrl)
+				mockTx.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockResult, nil)
 				mockTx.EXPECT().Rollback().Return(nil)
 				mockDB := proxy.NewMockDB(mockCtrl)
 				mockDB.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
-				mockDB.EXPECT().PrepareContext(gomock.Any(), gomock.Any()).Return(mockStmt, nil)
 				mockConnection := database.NewMockDBConnection(mockCtrl)
 				mockConnection.EXPECT().Open().Return(mockDB, nil)
 				mockConnManager := database.NewMockConnectionManager(mockCtrl)
@@ -6127,16 +6079,13 @@ func Test_historyRepository_SaveAll(t *testing.T) {
 			setup: func(mockCtrl *gomock.Controller, tt *fields) {
 				mockResult := proxy.NewMockResult(mockCtrl)
 				mockResult.EXPECT().LastInsertId().Return(int64(1), nil)
-				mockStmt := proxy.NewMockStmt(mockCtrl)
-				mockStmt.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockResult, nil)
-				mockStmt.EXPECT().Close().Return(nil)
 				mockTx := proxy.NewMockTx(mockCtrl)
+				mockTx.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(mockResult, nil)
 				mockTx.EXPECT().Commit().Return(errors.New("Tx.Commit() failed"))
 				mockTx.EXPECT().Rollback().Return(nil)
 				mockDB := proxy.NewMockDB(mockCtrl)
 				mockDB.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil)
 				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
-				mockDB.EXPECT().PrepareContext(gomock.Any(), gomock.Any()).Return(mockStmt, nil)
 				mockConnection := database.NewMockDBConnection(mockCtrl)
 				mockConnection.EXPECT().Open().Return(mockDB, nil)
 				mockConnManager := database.NewMockConnectionManager(mockCtrl)

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -1683,7 +1683,26 @@ func (h *historyRepository) FindTopNByPhraseContainsOrderByIdAsc(
 
 // SaveAll is a method that saves all the jrp to the history table.
 func (h *historyRepository) SaveAll(ctx context.Context, jrps []*history.History) ([]*history.History, error) <span class="cov8" title="1">{
-        var deferErr error
+        if len(jrps) == 0 </span><span class="cov8" title="1">{
+                return jrps, nil
+        }</span>
+
+        <span class="cov8" title="1">valueStrings := make([]string, 0, len(jrps))
+        valueArgs := make([]interface{}, 0, len(jrps)*6)
+
+        for _, jrp := range jrps </span><span class="cov8" title="1">{
+                valueStrings = append(valueStrings, "(?, ?, ?, ?, ?, ?)")
+                valueArgs = append(valueArgs,
+                        jrp.Phrase,
+                        jrp.Prefix,
+                        jrp.Suffix,
+                        jrp.IsFavorited,
+                        jrp.CreatedAt,
+                        jrp.UpdatedAt,
+                )
+        }</span>
+
+        <span class="cov8" title="1">var deferErr error
         db, err := getJrpDB(ctx, h.connManager)
         if err != nil </span><span class="cov8" title="1">{
                 return nil, err
@@ -1703,34 +1722,21 @@ func (h *historyRepository) SaveAll(ctx context.Context, jrps []*history.History
                 deferErr = tx.Rollback()
         }</span>()
 
-        <span class="cov8" title="1">stmt, err := db.PrepareContext(ctx, InsertQuery)
+        <span class="cov8" title="1">query := fmt.Sprintf(InsertQuery, strings.Join(valueStrings, ","))
+        result, err := tx.ExecContext(ctx, query, valueArgs...)
         if err != nil </span><span class="cov8" title="1">{
                 return nil, err
         }</span>
-        <span class="cov8" title="1">defer func() </span><span class="cov8" title="1">{
-                deferErr = stmt.Close()
-        }</span>()
 
-        <span class="cov8" title="1">for _, jrp := range jrps </span><span class="cov8" title="1">{
-                res, err := stmt.ExecContext(
-                        ctx,
-                        jrp.Phrase,
-                        jrp.Prefix,
-                        jrp.Suffix,
-                        jrp.IsFavorited,
-                        jrp.CreatedAt,
-                        jrp.UpdatedAt,
-                )
-                if err != nil </span><span class="cov8" title="1">{
-                        return nil, err
-                }</span>
+        <span class="cov8" title="1">lastID, err := result.LastInsertId()
+        if err != nil </span><span class="cov8" title="1">{
+                return nil, err
+        }</span>
+        <span class="cov8" title="1">firstID := lastID - int64(len(jrps)) + 1
 
-                <span class="cov8" title="1">i, err := res.LastInsertId()
-                if err != nil </span><span class="cov8" title="1">{
-                        return nil, err
-                }</span>
-                <span class="cov8" title="1">jrp.ID = int(i)</span>
-        }
+        for i, jrp := range jrps </span><span class="cov8" title="1">{
+                jrp.ID = int(firstID) + i
+        }</span>
 
         <span class="cov8" title="1">if err := tx.Commit(); err != nil </span><span class="cov8" title="1">{
                 return nil, err


### PR DESCRIPTION
- replace multiple single inserts with bulk insert using VALUES clause
- improve performance by reducing number of database calls
- calculate IDs for inserted records using first ID and offset
- add empty slice check to avoid unnecessary database calls
- update comment to reflect multiple records insertion