### PR TITLE
🔨refactor: remove unnecessary Version field from cli struct

### DIFF
--- a/app/application/jrp/get_history_usecase.go
+++ b/app/application/jrp/get_history_usecase.go
@@ -23,19 +23,19 @@ func NewGetHistoryUseCase(
 
 // GetHistoryUseCaseOutputDto is a DTO struct that contains the output data of the GetHistoryUseCase.
 type GetHistoryUseCaseOutputDto struct {
-	// ID is the identifier of the phrase
+	// ID is the identifier of the phrase.
 	ID int
-	// Phrase is the generated phrase
+	// Phrase is the generated phrase.
 	Phrase string
-	// Prefix is the prefix when the phrase is generated
+	// Prefix is the prefix when the phrase is generated.
 	Prefix string
-	// Suffix is the suffix when the phrase is generated
+	// Suffix is the suffix when the phrase is generated.
 	Suffix string
-	// IsFavorited is the flag to indicate whether the phrase is favorited
+	// IsFavorited is the flag to indicate whether the phrase is favorited.
 	IsFavorited int
-	// CreatedAt is the timestamp when the phrase is created
+	// CreatedAt is the timestamp when the phrase is created.
 	CreatedAt time.Time
-	// UpdatedAt is the timestamp when the phrase is updated
+	// UpdatedAt is the timestamp when the phrase is updated.
 	UpdatedAt time.Time
 }
 

--- a/app/application/jrp/save_history_usecase.go
+++ b/app/application/jrp/save_history_usecase.go
@@ -23,35 +23,35 @@ func NewSaveHistoryUseCase(
 
 // SaveHistoryUseCaseInputDto is a DTO struct that contains the output data of the SaveHistoryUseCase.
 type SaveHistoryUseCaseInputDto struct {
-	// Phrase is the generated phrase
+	// Phrase is the generated phrase.
 	Phrase string
-	// Prefix is the prefix when the phrase is generated
+	// Prefix is the prefix when the phrase is generated.
 	Prefix string
-	// Suffix is the suffix when the phrase is generated
+	// Suffix is the suffix when the phrase is generated.
 	Suffix string
-	// IsFavorited is the flag to indicate whether the phrase is favorited
+	// IsFavorited is the flag to indicate whether the phrase is favorited.
 	IsFavorited int
-	// CreatedAt is the timestamp when the phrase is created
+	// CreatedAt is the timestamp when the phrase is created.
 	CreatedAt time.Time
-	// UpdatedAt is the timestamp when the phrase is updated
+	// UpdatedAt is the timestamp when the phrase is updated.
 	UpdatedAt time.Time
 }
 
 // SaveHistoryUseCaseOutputDto is a DTO struct that contains the output data of the SaveHistoryUseCase.
 type SaveHistoryUseCaseOutputDto struct {
-	// ID is the identifier of the phrase
+	// ID is the identifier of the phrase.
 	ID int
-	// Phrase is the generated phrase
+	// Phrase is the generated phrase.
 	Phrase string
-	// Prefix is the prefix when the phrase is generated
+	// Prefix is the prefix when the phrase is generated.
 	Prefix string
-	// Suffix is the suffix when the phrase is generated
+	// Suffix is the suffix when the phrase is generated.
 	Suffix string
-	// IsFavorited is the flag to indicate whether the phrase is favorited
+	// IsFavorited is the flag to indicate whether the phrase is favorited.
 	IsFavorited int
-	// CreatedAt is the timestamp when the phrase is created
+	// CreatedAt is the timestamp when the phrase is created.
 	CreatedAt time.Time
-	// UpdatedAt is the timestamp when the phrase is updated
+	// UpdatedAt is the timestamp when the phrase is updated.
 	UpdatedAt time.Time
 }
 

--- a/app/application/jrp/search_history_usecase.go
+++ b/app/application/jrp/search_history_usecase.go
@@ -23,19 +23,19 @@ func NewSearchHistoryUseCase(
 
 // SearchHistoryUseCaseOutputDto is a DTO struct that contains the output data of the SearchHistoryUseCase.
 type SearchHistoryUseCaseOutputDto struct {
-	// ID is the identifier of the phrase
+	// ID is the identifier of the phrase.
 	ID int
-	// Phrase is the generated phrase
+	// Phrase is the generated phrase.
 	Phrase string
-	// Prefix is the prefix when the phrase is generated
+	// Prefix is the prefix when the phrase is generated.
 	Prefix string
-	// Suffix is the suffix when the phrase is generated
+	// Suffix is the suffix when the phrase is generated.
 	Suffix string
-	// IsFavorited is the flag to indicate whether the phrase is favorited
+	// IsFavorited is the flag to indicate whether the phrase is favorited.
 	IsFavorited int
-	// CreatedAt is the timestamp when the phrase is created
+	// CreatedAt is the timestamp when the phrase is created.
 	CreatedAt time.Time
-	// UpdatedAt is the timestamp when the phrase is updated
+	// UpdatedAt is the timestamp when the phrase is updated.
 	UpdatedAt time.Time
 }
 

--- a/app/domain/jrp/history/history_model.go
+++ b/app/domain/jrp/history/history_model.go
@@ -5,21 +5,21 @@ import (
 	"time"
 )
 
-// History is a struct that represents history table in the jrp database
+// History is a struct that represents history table in the jrp database.
 type History struct {
-	// ID is the primary key of the history table
+	// ID is the primary key of the history table.
 	ID int
-	// Phrase is the generated phrase
+	// Phrase is the generated phrase.
 	Phrase string
-	// Prefix is the prefix when the phrase is generated
+	// Prefix is the prefix when the phrase is generated.
 	Prefix sql.NullString
-	// Suffix is the suffix when the phrase is generated
+	// Suffix is the suffix when the phrase is generated.
 	Suffix sql.NullString
-	// IsFavorited is the flag to indicate whether the phrase is favorited
+	// IsFavorited is the flag to indicate whether the phrase is favorited.
 	IsFavorited int
-	// CreatedAt is the timestamp when the phrase is created
+	// CreatedAt is the timestamp when the phrase is created.
 	CreatedAt time.Time
-	// UpdatedAt is the timestamp when the phrase is updated
+	// UpdatedAt is the timestamp when the phrase is updated.
 	UpdatedAt time.Time
 }
 

--- a/app/presentation/cli/jrp/command/command.go
+++ b/app/presentation/cli/jrp/command/command.go
@@ -14,9 +14,9 @@ import (
 )
 
 var (
-	// output is the output string
+	// output is the output string.
 	output = ""
-	// NewCli is a variable holding the current Cli creation function
+	// NewCli is a variable holding the current Cli creation function.
 	NewCli CreateCliFunc = newCli
 )
 
@@ -28,20 +28,19 @@ type Cli interface {
 // cli is a struct that represents the command line interface of jrp cli.
 type cli struct {
 	Cobra             proxy.Cobra
-	Version           string
 	RootCommand       proxy.Command
 	ConnectionManager database.ConnectionManager
 }
 
-// CreateCliFunc is a function type for creating new Cli instances
+// CreateCliFunc is a function type for creating new Cli instances.
 type CreateCliFunc func(cobra proxy.Cobra) Cli
 
-// newCli is the default implementation of CreateCliFunc
+// newCli is the default implementation of CreateCliFunc.
 func newCli(cobra proxy.Cobra) Cli {
 	return &cli{
-		Cobra:       cobra,
-		Version:     "",
-		RootCommand: nil,
+		Cobra:             cobra,
+		RootCommand:       nil,
+		ConnectionManager: nil,
 	}
 }
 
@@ -93,11 +92,9 @@ func (c *cli) Init(
 		}
 	}
 
-	ver := versionUtil.GetVersion(version)
-
 	c.RootCommand = NewRootCommand(
 		c.Cobra,
-		ver,
+		versionUtil.GetVersion(version),
 		conf,
 		&output,
 	)

--- a/app/presentation/cli/jrp/command/command_test.go
+++ b/app/presentation/cli/jrp/command/command_test.go
@@ -35,7 +35,6 @@ func Test_newCli(t *testing.T) {
 			},
 			want: &cli{
 				Cobra:       cobra,
-				Version:     "",
 				RootCommand: nil,
 			},
 		},
@@ -85,7 +84,6 @@ func Test_cli_Init(t *testing.T) {
 				fnc: func(_ *gomock.Controller) {
 					c := &cli{
 						Cobra:             cobra,
-						Version:           "",
 						RootCommand:       nil,
 						ConnectionManager: nil,
 					}
@@ -161,7 +159,6 @@ func Test_cli_Init(t *testing.T) {
 					mockEnvconfig.EXPECT().Process("", gomock.Any()).Return(errors.New("EnvconfigProxy.Process() failed"))
 					c := &cli{
 						Cobra:             cobra,
-						Version:           "",
 						RootCommand:       nil,
 						ConnectionManager: nil,
 					}
@@ -237,7 +234,6 @@ func Test_cli_Init(t *testing.T) {
 					mockConnectionManager.EXPECT().InitializeConnection(gomock.Any()).Return(errors.New("ConnectionManager.InitializeConnection() failed"))
 					c := &cli{
 						Cobra:             cobra,
-						Version:           "",
 						RootCommand:       nil,
 						ConnectionManager: mockConnectionManager,
 					}
@@ -314,7 +310,6 @@ func Test_cli_Init(t *testing.T) {
 					mockConnectionManager.EXPECT().InitializeConnection(gomock.Any()).Return(errors.New("ConnectionManager.InitializeConnection() failed"))
 					c := &cli{
 						Cobra:             cobra,
-						Version:           "",
 						RootCommand:       nil,
 						ConnectionManager: mockConnectionManager,
 					}
@@ -445,7 +440,6 @@ func Test_cli_Run(t *testing.T) {
 					mockConnectionManager.EXPECT().CloseAllConnections().Return(nil)
 					c := &cli{
 						Cobra:             proxy.NewCobra(),
-						Version:           "",
 						RootCommand:       mockCommand,
 						ConnectionManager: mockConnectionManager,
 					}
@@ -478,7 +472,6 @@ func Test_cli_Run(t *testing.T) {
 					mockConnectionManager.EXPECT().CloseAllConnections().Return(nil)
 					c := &cli{
 						Cobra:             proxy.NewCobra(),
-						Version:           "",
 						RootCommand:       mockCommand,
 						ConnectionManager: mockConnectionManager,
 					}
@@ -511,7 +504,6 @@ func Test_cli_Run(t *testing.T) {
 					mockConnectionManager.EXPECT().CloseAllConnections().Return(errors.New("ConnectionManager.CloseAllConnections() failed"))
 					c := &cli{
 						Cobra:             proxy.NewCobra(),
-						Version:           "0.0.0",
 						RootCommand:       mockCommand,
 						ConnectionManager: mockConnectionManager,
 					}

--- a/app/presentation/cli/jrp/presenter/keyboard.go
+++ b/app/presentation/cli/jrp/presenter/keyboard.go
@@ -15,7 +15,7 @@ func CloseKeyboard() {
 	Ku.CloseKeyboard()
 }
 
-// GetKey
+// GetKey gets a key from the keyboard.
 func GetKey(timeoutSec int) (string, error) {
 	return Ku.GetKey(timeoutSec)
 }

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -456,19 +456,19 @@ func NewGetHistoryUseCase(
 
 // GetHistoryUseCaseOutputDto is a DTO struct that contains the output data of the GetHistoryUseCase.
 type GetHistoryUseCaseOutputDto struct {
-        // ID is the identifier of the phrase
+        // ID is the identifier of the phrase.
         ID int
-        // Phrase is the generated phrase
+        // Phrase is the generated phrase.
         Phrase string
-        // Prefix is the prefix when the phrase is generated
+        // Prefix is the prefix when the phrase is generated.
         Prefix string
-        // Suffix is the suffix when the phrase is generated
+        // Suffix is the suffix when the phrase is generated.
         Suffix string
-        // IsFavorited is the flag to indicate whether the phrase is favorited
+        // IsFavorited is the flag to indicate whether the phrase is favorited.
         IsFavorited int
-        // CreatedAt is the timestamp when the phrase is created
+        // CreatedAt is the timestamp when the phrase is created.
         CreatedAt time.Time
-        // UpdatedAt is the timestamp when the phrase is updated
+        // UpdatedAt is the timestamp when the phrase is updated.
         UpdatedAt time.Time
 }
 
@@ -603,35 +603,35 @@ func NewSaveHistoryUseCase(
 
 // SaveHistoryUseCaseInputDto is a DTO struct that contains the output data of the SaveHistoryUseCase.
 type SaveHistoryUseCaseInputDto struct {
-        // Phrase is the generated phrase
+        // Phrase is the generated phrase.
         Phrase string
-        // Prefix is the prefix when the phrase is generated
+        // Prefix is the prefix when the phrase is generated.
         Prefix string
-        // Suffix is the suffix when the phrase is generated
+        // Suffix is the suffix when the phrase is generated.
         Suffix string
-        // IsFavorited is the flag to indicate whether the phrase is favorited
+        // IsFavorited is the flag to indicate whether the phrase is favorited.
         IsFavorited int
-        // CreatedAt is the timestamp when the phrase is created
+        // CreatedAt is the timestamp when the phrase is created.
         CreatedAt time.Time
-        // UpdatedAt is the timestamp when the phrase is updated
+        // UpdatedAt is the timestamp when the phrase is updated.
         UpdatedAt time.Time
 }
 
 // SaveHistoryUseCaseOutputDto is a DTO struct that contains the output data of the SaveHistoryUseCase.
 type SaveHistoryUseCaseOutputDto struct {
-        // ID is the identifier of the phrase
+        // ID is the identifier of the phrase.
         ID int
-        // Phrase is the generated phrase
+        // Phrase is the generated phrase.
         Phrase string
-        // Prefix is the prefix when the phrase is generated
+        // Prefix is the prefix when the phrase is generated.
         Prefix string
-        // Suffix is the suffix when the phrase is generated
+        // Suffix is the suffix when the phrase is generated.
         Suffix string
-        // IsFavorited is the flag to indicate whether the phrase is favorited
+        // IsFavorited is the flag to indicate whether the phrase is favorited.
         IsFavorited int
-        // CreatedAt is the timestamp when the phrase is created
+        // CreatedAt is the timestamp when the phrase is created.
         CreatedAt time.Time
-        // UpdatedAt is the timestamp when the phrase is updated
+        // UpdatedAt is the timestamp when the phrase is updated.
         UpdatedAt time.Time
 }
 
@@ -698,19 +698,19 @@ func NewSearchHistoryUseCase(
 
 // SearchHistoryUseCaseOutputDto is a DTO struct that contains the output data of the SearchHistoryUseCase.
 type SearchHistoryUseCaseOutputDto struct {
-        // ID is the identifier of the phrase
+        // ID is the identifier of the phrase.
         ID int
-        // Phrase is the generated phrase
+        // Phrase is the generated phrase.
         Phrase string
-        // Prefix is the prefix when the phrase is generated
+        // Prefix is the prefix when the phrase is generated.
         Prefix string
-        // Suffix is the suffix when the phrase is generated
+        // Suffix is the suffix when the phrase is generated.
         Suffix string
-        // IsFavorited is the flag to indicate whether the phrase is favorited
+        // IsFavorited is the flag to indicate whether the phrase is favorited.
         IsFavorited int
-        // CreatedAt is the timestamp when the phrase is created
+        // CreatedAt is the timestamp when the phrase is created.
         CreatedAt time.Time
-        // UpdatedAt is the timestamp when the phrase is updated
+        // UpdatedAt is the timestamp when the phrase is updated.
         UpdatedAt time.Time
 }
 
@@ -899,21 +899,21 @@ import (
         "time"
 )
 
-// History is a struct that represents history table in the jrp database
+// History is a struct that represents history table in the jrp database.
 type History struct {
-        // ID is the primary key of the history table
+        // ID is the primary key of the history table.
         ID int
-        // Phrase is the generated phrase
+        // Phrase is the generated phrase.
         Phrase string
-        // Prefix is the prefix when the phrase is generated
+        // Prefix is the prefix when the phrase is generated.
         Prefix sql.NullString
-        // Suffix is the suffix when the phrase is generated
+        // Suffix is the suffix when the phrase is generated.
         Suffix sql.NullString
-        // IsFavorited is the flag to indicate whether the phrase is favorited
+        // IsFavorited is the flag to indicate whether the phrase is favorited.
         IsFavorited int
-        // CreatedAt is the timestamp when the phrase is created
+        // CreatedAt is the timestamp when the phrase is created.
         CreatedAt time.Time
-        // UpdatedAt is the timestamp when the phrase is updated
+        // UpdatedAt is the timestamp when the phrase is updated.
         UpdatedAt time.Time
 }
 
@@ -1917,9 +1917,9 @@ import (
 )
 
 var (
-        // output is the output string
+        // output is the output string.
         output = ""
-        // NewCli is a variable holding the current Cli creation function
+        // NewCli is a variable holding the current Cli creation function.
         NewCli CreateCliFunc = newCli
 )
 
@@ -1931,20 +1931,19 @@ type Cli interface {
 // cli is a struct that represents the command line interface of jrp cli.
 type cli struct {
         Cobra             proxy.Cobra
-        Version           string
         RootCommand       proxy.Command
         ConnectionManager database.ConnectionManager
 }
 
-// CreateCliFunc is a function type for creating new Cli instances
+// CreateCliFunc is a function type for creating new Cli instances.
 type CreateCliFunc func(cobra proxy.Cobra) Cli
 
-// newCli is the default implementation of CreateCliFunc
+// newCli is the default implementation of CreateCliFunc.
 func newCli(cobra proxy.Cobra) Cli <span class="cov8" title="1">{
         return &amp;cli{
-                Cobra:       cobra,
-                Version:     "",
-                RootCommand: nil,
+                Cobra:             cobra,
+                RootCommand:       nil,
+                ConnectionManager: nil,
         }
 }</span>
 
@@ -1996,11 +1995,9 @@ func (c *cli) Init(
                 }</span>
         }
 
-        <span class="cov8" title="1">ver := versionUtil.GetVersion(version)
-
-        c.RootCommand = NewRootCommand(
+        <span class="cov8" title="1">c.RootCommand = NewRootCommand(
                 c.Cobra,
-                ver,
+                versionUtil.GetVersion(version),
                 conf,
                 &amp;output,
         )
@@ -4956,7 +4953,7 @@ func CloseKeyboard() <span class="cov8" title="1">{
         Ku.CloseKeyboard()
 }</span>
 
-// GetKey
+// GetKey gets a key from the keyboard.
 func GetKey(timeoutSec int) (string, error) <span class="cov8" title="1">{
         return Ku.GetKey(timeoutSec)
 }</span>
@@ -5554,7 +5551,7 @@ func NewVersionUtil(
 
 // GetVersion returns the version of the application.
 func (v *versionUtil) GetVersion(version string) string <span class="cov8" title="1">{
-        // if version is embedded, return it
+        // if version is embedded, return it.
         if version != "" </span><span class="cov8" title="1">{
                 return version
         }</span>

--- a/pkg/proxy/cobra.go
+++ b/pkg/proxy/cobra.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Cobra is an interface that provides a proxy of the methods of cobra
+// Cobra is an interface that provides a proxy of the methods of cobra.
 type Cobra interface {
 	ExactArgs(n int) cobra.PositionalArgs
 	MaximumNArgs(n int) cobra.PositionalArgs

--- a/pkg/proxy/spinner.go
+++ b/pkg/proxy/spinner.go
@@ -6,7 +6,7 @@ import (
 	"github.com/briandowns/spinner"
 )
 
-// Spinners is an interface that provides a proxy of the methods of spinner
+// Spinners is an interface that provides a proxy of the methods of spinner.
 type Spinners interface {
 	NewSpinner() Spinner
 }

--- a/pkg/proxy/sql.go
+++ b/pkg/proxy/sql.go
@@ -57,7 +57,7 @@ func (d *dbProxy) ExecContext(ctx context.Context, query string, args ...interfa
 	return &resultProxy{result: result}, err
 }
 
-// PrepareContext creates a prepared statement for later queries or executions
+// PrepareContext creates a prepared statement for later queries or executions.
 func (d *dbProxy) PrepareContext(ctx context.Context, query string) (Stmt, error) {
 	stmt, err := d.db.PrepareContext(ctx, query)
 	return &stmtProxy{stmt: stmt}, err

--- a/pkg/utility/version_util.go
+++ b/pkg/utility/version_util.go
@@ -25,7 +25,7 @@ func NewVersionUtil(
 
 // GetVersion returns the version of the application.
 func (v *versionUtil) GetVersion(version string) string {
-	// if version is embedded, return it
+	// if version is embedded, return it.
 	if version != "" {
 		return version
 	}


### PR DESCRIPTION
- remove unused `Version` field from `cli` struct
- format code style in `newCli` function
- simplify version initialization in `Init` method