### PR TITLE
🔨refactor: move JRP DB settings from `JrpConfig` to `JrpCliConfig`

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -20,8 +20,6 @@ type BaseConfigurator struct {
 
 // JrpConfig is a struct that contains the configuration of the Jrp application.
 type JrpConfig struct {
-	JrpDBType   database.DBType
-	JrpDBDsn    string
 	WNJpnDBType database.DBType
 	WNJpnDBDsn  string
 }

--- a/app/presentation/cli/jrp/command/jrp/download_test.go
+++ b/app/presentation/cli/jrp/command/jrp/download_test.go
@@ -35,11 +35,11 @@ func TestNewDownloadCommand(t *testing.T) {
 				cobra: proxy.NewCobra(),
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: new(string),
 			},
@@ -83,11 +83,11 @@ func Test_runDownload(t *testing.T) {
 			args: args{
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},
@@ -106,11 +106,11 @@ func Test_runDownload(t *testing.T) {
 			args: args{
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},
@@ -129,11 +129,11 @@ func Test_runDownload(t *testing.T) {
 			args: args{
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "test",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},
@@ -149,11 +149,11 @@ func Test_runDownload(t *testing.T) {
 			args: args{
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},
@@ -178,11 +178,11 @@ func Test_runDownload(t *testing.T) {
 			args: args{
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},

--- a/app/presentation/cli/jrp/command/root_test.go
+++ b/app/presentation/cli/jrp/command/root_test.go
@@ -43,11 +43,11 @@ func TestNewRootCommand(t *testing.T) {
 				version: "0.0.0",
 				conf: &config.JrpCliConfig{
 					JrpConfig: baseConfig.JrpConfig{
-						JrpDBType:   "sqlite",
-						JrpDBDsn:    filepath.Join(os.TempDir(), "jrp.db"),
 						WNJpnDBType: "sqlite",
 						WNJpnDBDsn:  filepath.Join(os.TempDir(), "wnjpn.db"),
 					},
+					JrpDBType: "sqlite",
+					JrpDBDsn:  filepath.Join(os.TempDir(), "jrp.db"),
 				},
 				output: &output,
 			},

--- a/app/presentation/cli/jrp/config/config.go
+++ b/app/presentation/cli/jrp/config/config.go
@@ -37,6 +37,8 @@ func NewJrpCliConfigurator(
 // JrpCliConfig is a struct that contains the configuration of the Jrp cli application.
 type JrpCliConfig struct {
 	baseConfig.JrpConfig
+	JrpDBType database.DBType
+	JrpDBDsn  string
 }
 
 // envConfig is a struct that contains the environment variables.
@@ -56,11 +58,11 @@ func (c *cliConfigurator) GetConfig() (*JrpCliConfig, error) {
 
 	config := &JrpCliConfig{
 		JrpConfig: baseConfig.JrpConfig{
-			JrpDBType:   env.JrpDBType,
-			JrpDBDsn:    env.JrpDBDsn,
 			WNJpnDBType: env.WnJpnDBType,
 			WNJpnDBDsn:  env.WnJpnDBDsn,
 		},
+		JrpDBType: env.JrpDBType,
+		JrpDBDsn:  env.JrpDBDsn,
 	}
 
 	if config.JrpDBType == database.SQLite || config.WNJpnDBType == database.SQLite {

--- a/app/presentation/cli/jrp/config/config_test.go
+++ b/app/presentation/cli/jrp/config/config_test.go
@@ -74,11 +74,11 @@ func Test_cliConfigurator_GetConfig(t *testing.T) {
 				}},
 			want: &JrpCliConfig{
 				JrpConfig: baseConfig.JrpConfig{
-					JrpDBType:   database.SQLite,
-					JrpDBDsn:    "~/.local/share/jrp/jrp.db",
 					WNJpnDBType: database.SQLite,
 					WNJpnDBDsn:  "~/.local/share/jrp/wnjpn.db",
 				},
+				JrpDBType: database.SQLite,
+				JrpDBDsn:  "~/.local/share/jrp/jrp.db",
 			},
 			wantErr: false,
 			setup: func(mockCtrl *gomock.Controller, tt *fields) {

--- a/docs/coverage.html
+++ b/docs/coverage.html
@@ -892,8 +892,6 @@ type BaseConfigurator struct {
 
 // JrpConfig is a struct that contains the configuration of the Jrp application.
 type JrpConfig struct {
-        JrpDBType   database.DBType
-        JrpDBDsn    string
         WNJpnDBType database.DBType
         WNJpnDBDsn  string
 }
@@ -4998,6 +4996,8 @@ func NewJrpCliConfigurator(
 // JrpCliConfig is a struct that contains the configuration of the Jrp cli application.
 type JrpCliConfig struct {
         baseConfig.JrpConfig
+        JrpDBType database.DBType
+        JrpDBDsn  string
 }
 
 // envConfig is a struct that contains the environment variables.
@@ -5017,11 +5017,11 @@ func (c *cliConfigurator) GetConfig() (*JrpCliConfig, error) <span class="cov8" 
 
         <span class="cov8" title="1">config := &amp;JrpCliConfig{
                 JrpConfig: baseConfig.JrpConfig{
-                        JrpDBType:   env.JrpDBType,
-                        JrpDBDsn:    env.JrpDBDsn,
                         WNJpnDBType: env.WnJpnDBType,
                         WNJpnDBDsn:  env.WnJpnDBDsn,
                 },
+                JrpDBType: env.JrpDBType,
+                JrpDBDsn:  env.JrpDBDsn,
         }
 
         if config.JrpDBType == database.SQLite || config.WNJpnDBType == database.SQLite </span><span class="cov8" title="1">{


### PR DESCRIPTION
- move `JrpDBType` and `JrpDBDsn` from base `JrpConfig` to `JrpCliConfig`
- update related test cases to reflect the structure change
- this change separates CLI specific DB configurations from base config