### PR TITLE
👷chore: Upgrade Golang version in container from `1.23` to `1.24`

### DIFF
--- a/ops/docker/app/Dockerfile
+++ b/ops/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23
+FROM golang:1.24
 RUN apt-get update && apt-get install -y curl unzip
 RUN curl -L -O https://github.com/sagiegurari/cargo-make/releases/download/0.37.14/cargo-make-v0.37.14-x86_64-unknown-linux-musl.zip \
   && unzip cargo-make-v0.37.14-x86_64-unknown-linux-musl.zip \


### PR DESCRIPTION
- update the base image in Docker container to use latest Golang version
- ensure compatibility with the newest Golang features and security  updates