### PR TITLE
🔨refactor: add `isgomock` marker field to all mock structs

### DIFF
--- a/app/application/wnjpn/word_query_service_mock.go
+++ b/app/application/wnjpn/word_query_service_mock.go
@@ -20,6 +20,7 @@ import (
 type MockWordQueryService struct {
 	ctrl     *gomock.Controller
 	recorder *MockWordQueryServiceMockRecorder
+	isgomock struct{}
 }
 
 // MockWordQueryServiceMockRecorder is the mock recorder for MockWordQueryService.

--- a/app/domain/jrp/history/history_repository_mock.go
+++ b/app/domain/jrp/history/history_repository_mock.go
@@ -20,6 +20,7 @@ import (
 type MockHistoryRepository struct {
 	ctrl     *gomock.Controller
 	recorder *MockHistoryRepositoryMockRecorder
+	isgomock struct{}
 }
 
 // MockHistoryRepositoryMockRecorder is the mock recorder for MockHistoryRepository.

--- a/app/infrastructure/database/connection_manager_mock.go
+++ b/app/infrastructure/database/connection_manager_mock.go
@@ -19,6 +19,7 @@ import (
 type MockConnectionManager struct {
 	ctrl     *gomock.Controller
 	recorder *MockConnectionManagerMockRecorder
+	isgomock struct{}
 }
 
 // MockConnectionManagerMockRecorder is the mock recorder for MockConnectionManager.

--- a/app/infrastructure/database/connection_mock.go
+++ b/app/infrastructure/database/connection_mock.go
@@ -20,6 +20,7 @@ import (
 type MockDBConnection struct {
 	ctrl     *gomock.Controller
 	recorder *MockDBConnectionMockRecorder
+	isgomock struct{}
 }
 
 // MockDBConnectionMockRecorder is the mock recorder for MockDBConnection.

--- a/app/presentation/api/jrp-server/server/server_mock.go
+++ b/app/presentation/api/jrp-server/server/server_mock.go
@@ -21,6 +21,7 @@ import (
 type MockServer struct {
 	ctrl     *gomock.Controller
 	recorder *MockServerMockRecorder
+	isgomock struct{}
 }
 
 // MockServerMockRecorder is the mock recorder for MockServer.

--- a/app/presentation/cli/jrp/command/command_mock.go
+++ b/app/presentation/cli/jrp/command/command_mock.go
@@ -22,6 +22,7 @@ import (
 type MockCli struct {
 	ctrl     *gomock.Controller
 	recorder *MockCliMockRecorder
+	isgomock struct{}
 }
 
 // MockCliMockRecorder is the mock recorder for MockCli.

--- a/pkg/proxy/buffer_mock.go
+++ b/pkg/proxy/buffer_mock.go
@@ -20,6 +20,7 @@ import (
 type MockBuffer struct {
 	ctrl     *gomock.Controller
 	recorder *MockBufferMockRecorder
+	isgomock struct{}
 }
 
 // MockBufferMockRecorder is the mock recorder for MockBuffer.

--- a/pkg/proxy/cobra_mock.go
+++ b/pkg/proxy/cobra_mock.go
@@ -21,6 +21,7 @@ import (
 type MockCobra struct {
 	ctrl     *gomock.Controller
 	recorder *MockCobraMockRecorder
+	isgomock struct{}
 }
 
 // MockCobraMockRecorder is the mock recorder for MockCobra.
@@ -86,6 +87,7 @@ func (mr *MockCobraMockRecorder) NewCommand() *gomock.Call {
 type MockCommand struct {
 	ctrl     *gomock.Controller
 	recorder *MockCommandMockRecorder
+	isgomock struct{}
 }
 
 // MockCommandMockRecorder is the mock recorder for MockCommand.

--- a/pkg/proxy/debug_mock.go
+++ b/pkg/proxy/debug_mock.go
@@ -20,6 +20,7 @@ import (
 type MockDebug struct {
 	ctrl     *gomock.Controller
 	recorder *MockDebugMockRecorder
+	isgomock struct{}
 }
 
 // MockDebugMockRecorder is the mock recorder for MockDebug.

--- a/pkg/proxy/echo_mock.go
+++ b/pkg/proxy/echo_mock.go
@@ -20,6 +20,7 @@ import (
 type MockEchos struct {
 	ctrl     *gomock.Controller
 	recorder *MockEchosMockRecorder
+	isgomock struct{}
 }
 
 // MockEchosMockRecorder is the mock recorder for MockEchos.
@@ -58,6 +59,7 @@ func (mr *MockEchosMockRecorder) NewEcho() *gomock.Call {
 type MockEcho struct {
 	ctrl     *gomock.Controller
 	recorder *MockEchoMockRecorder
+	isgomock struct{}
 }
 
 // MockEchoMockRecorder is the mock recorder for MockEcho.
@@ -147,6 +149,7 @@ func (mr *MockEchoMockRecorder) Use(middleware ...any) *gomock.Call {
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
+	isgomock struct{}
 }
 
 // MockLoggerMockRecorder is the mock recorder for MockLogger.
@@ -182,6 +185,7 @@ func (mr *MockLoggerMockRecorder) Fatal(err any) *gomock.Call {
 type MockGroup struct {
 	ctrl     *gomock.Controller
 	recorder *MockGroupMockRecorder
+	isgomock struct{}
 }
 
 // MockGroupMockRecorder is the mock recorder for MockGroup.

--- a/pkg/proxy/envconfig_mock.go
+++ b/pkg/proxy/envconfig_mock.go
@@ -19,6 +19,7 @@ import (
 type MockEnvconfig struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnvconfigMockRecorder
+	isgomock struct{}
 }
 
 // MockEnvconfigMockRecorder is the mock recorder for MockEnvconfig.

--- a/pkg/proxy/gzip_mock.go
+++ b/pkg/proxy/gzip_mock.go
@@ -20,6 +20,7 @@ import (
 type MockGzip struct {
 	ctrl     *gomock.Controller
 	recorder *MockGzipMockRecorder
+	isgomock struct{}
 }
 
 // MockGzipMockRecorder is the mock recorder for MockGzip.
@@ -58,6 +59,7 @@ func (mr *MockGzipMockRecorder) NewReader(r any) *gomock.Call {
 type MockGzipReader struct {
 	ctrl     *gomock.Controller
 	recorder *MockGzipReaderMockRecorder
+	isgomock struct{}
 }
 
 // MockGzipReaderMockRecorder is the mock recorder for MockGzipReader.

--- a/pkg/proxy/http_mock.go
+++ b/pkg/proxy/http_mock.go
@@ -19,6 +19,7 @@ import (
 type MockHttp struct {
 	ctrl     *gomock.Controller
 	recorder *MockHttpMockRecorder
+	isgomock struct{}
 }
 
 // MockHttpMockRecorder is the mock recorder for MockHttp.
@@ -57,6 +58,7 @@ func (mr *MockHttpMockRecorder) Get(url any) *gomock.Call {
 type MockResponse struct {
 	ctrl     *gomock.Controller
 	recorder *MockResponseMockRecorder
+	isgomock struct{}
 }
 
 // MockResponseMockRecorder is the mock recorder for MockResponse.
@@ -108,6 +110,7 @@ func (mr *MockResponseMockRecorder) GetBody() *gomock.Call {
 type MockReadCloser struct {
 	ctrl     *gomock.Controller
 	recorder *MockReadCloserMockRecorder
+	isgomock struct{}
 }
 
 // MockReadCloserMockRecorder is the mock recorder for MockReadCloser.

--- a/pkg/proxy/io_mock.go
+++ b/pkg/proxy/io_mock.go
@@ -20,6 +20,7 @@ import (
 type MockIo struct {
 	ctrl     *gomock.Controller
 	recorder *MockIoMockRecorder
+	isgomock struct{}
 }
 
 // MockIoMockRecorder is the mock recorder for MockIo.

--- a/pkg/proxy/json_mock.go
+++ b/pkg/proxy/json_mock.go
@@ -19,6 +19,7 @@ import (
 type MockJson struct {
 	ctrl     *gomock.Controller
 	recorder *MockJsonMockRecorder
+	isgomock struct{}
 }
 
 // MockJsonMockRecorder is the mock recorder for MockJson.

--- a/pkg/proxy/keyboard_mock.go
+++ b/pkg/proxy/keyboard_mock.go
@@ -20,6 +20,7 @@ import (
 type MockKeyboard struct {
 	ctrl     *gomock.Controller
 	recorder *MockKeyboardMockRecorder
+	isgomock struct{}
 }
 
 // MockKeyboardMockRecorder is the mock recorder for MockKeyboard.

--- a/pkg/proxy/os_mock.go
+++ b/pkg/proxy/os_mock.go
@@ -20,6 +20,7 @@ import (
 type MockOs struct {
 	ctrl     *gomock.Controller
 	recorder *MockOsMockRecorder
+	isgomock struct{}
 }
 
 // MockOsMockRecorder is the mock recorder for MockOs.
@@ -203,6 +204,7 @@ func (mr *MockOsMockRecorder) UserHomeDir() *gomock.Call {
 type MockFile struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileMockRecorder
+	isgomock struct{}
 }
 
 // MockFileMockRecorder is the mock recorder for MockFile.

--- a/pkg/proxy/pflag_mock.go
+++ b/pkg/proxy/pflag_mock.go
@@ -19,6 +19,7 @@ import (
 type MockFlagSet struct {
 	ctrl     *gomock.Controller
 	recorder *MockFlagSetMockRecorder
+	isgomock struct{}
 }
 
 // MockFlagSetMockRecorder is the mock recorder for MockFlagSet.

--- a/pkg/proxy/promptui_mock.go
+++ b/pkg/proxy/promptui_mock.go
@@ -19,6 +19,7 @@ import (
 type MockPromptui struct {
 	ctrl     *gomock.Controller
 	recorder *MockPromptuiMockRecorder
+	isgomock struct{}
 }
 
 // MockPromptuiMockRecorder is the mock recorder for MockPromptui.
@@ -56,6 +57,7 @@ func (mr *MockPromptuiMockRecorder) NewPrompt() *gomock.Call {
 type MockPrompt struct {
 	ctrl     *gomock.Controller
 	recorder *MockPromptMockRecorder
+	isgomock struct{}
 }
 
 // MockPromptMockRecorder is the mock recorder for MockPrompt.

--- a/pkg/proxy/rand_mock.go
+++ b/pkg/proxy/rand_mock.go
@@ -19,6 +19,7 @@ import (
 type MockRand struct {
 	ctrl     *gomock.Controller
 	recorder *MockRandMockRecorder
+	isgomock struct{}
 }
 
 // MockRandMockRecorder is the mock recorder for MockRand.

--- a/pkg/proxy/spinner_mock.go
+++ b/pkg/proxy/spinner_mock.go
@@ -19,6 +19,7 @@ import (
 type MockSpinners struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpinnersMockRecorder
+	isgomock struct{}
 }
 
 // MockSpinnersMockRecorder is the mock recorder for MockSpinners.
@@ -56,6 +57,7 @@ func (mr *MockSpinnersMockRecorder) NewSpinner() *gomock.Call {
 type MockSpinner struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpinnerMockRecorder
+	isgomock struct{}
 }
 
 // MockSpinnerMockRecorder is the mock recorder for MockSpinner.

--- a/pkg/proxy/sql_mock.go
+++ b/pkg/proxy/sql_mock.go
@@ -21,6 +21,7 @@ import (
 type MockSql struct {
 	ctrl     *gomock.Controller
 	recorder *MockSqlMockRecorder
+	isgomock struct{}
 }
 
 // MockSqlMockRecorder is the mock recorder for MockSql.
@@ -59,6 +60,7 @@ func (mr *MockSqlMockRecorder) Open(driverName, dataSourceName any) *gomock.Call
 type MockDB struct {
 	ctrl     *gomock.Controller
 	recorder *MockDBMockRecorder
+	isgomock struct{}
 }
 
 // MockDBMockRecorder is the mock recorder for MockDB.
@@ -166,6 +168,7 @@ func (mr *MockDBMockRecorder) QueryContext(ctx, query any, args ...any) *gomock.
 type MockRows struct {
 	ctrl     *gomock.Controller
 	recorder *MockRowsMockRecorder
+	isgomock struct{}
 }
 
 // MockRowsMockRecorder is the mock recorder for MockRows.
@@ -235,6 +238,7 @@ func (mr *MockRowsMockRecorder) Scan(dest ...any) *gomock.Call {
 type MockResult struct {
 	ctrl     *gomock.Controller
 	recorder *MockResultMockRecorder
+	isgomock struct{}
 }
 
 // MockResultMockRecorder is the mock recorder for MockResult.
@@ -288,6 +292,7 @@ func (mr *MockResultMockRecorder) RowsAffected() *gomock.Call {
 type MockTx struct {
 	ctrl     *gomock.Controller
 	recorder *MockTxMockRecorder
+	isgomock struct{}
 }
 
 // MockTxMockRecorder is the mock recorder for MockTx.
@@ -359,6 +364,7 @@ func (mr *MockTxMockRecorder) Rollback() *gomock.Call {
 type MockStmt struct {
 	ctrl     *gomock.Controller
 	recorder *MockStmtMockRecorder
+	isgomock struct{}
 }
 
 // MockStmtMockRecorder is the mock recorder for MockStmt.

--- a/pkg/proxy/tablewriter_mock.go
+++ b/pkg/proxy/tablewriter_mock.go
@@ -20,6 +20,7 @@ import (
 type MockTableWriter struct {
 	ctrl     *gomock.Controller
 	recorder *MockTableWriterMockRecorder
+	isgomock struct{}
 }
 
 // MockTableWriterMockRecorder is the mock recorder for MockTableWriter.
@@ -57,6 +58,7 @@ func (mr *MockTableWriterMockRecorder) NewTable(writer any) *gomock.Call {
 type MockTable struct {
 	ctrl     *gomock.Controller
 	recorder *MockTableMockRecorder
+	isgomock struct{}
 }
 
 // MockTableMockRecorder is the mock recorder for MockTable.

--- a/pkg/utility/capture_mock.go
+++ b/pkg/utility/capture_mock.go
@@ -19,6 +19,7 @@ import (
 type MockCapturer struct {
 	ctrl     *gomock.Controller
 	recorder *MockCapturerMockRecorder
+	isgomock struct{}
 }
 
 // MockCapturerMockRecorder is the mock recorder for MockCapturer.

--- a/pkg/utility/download_util_mock.go
+++ b/pkg/utility/download_util_mock.go
@@ -20,6 +20,7 @@ import (
 type MockDownloadUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockDownloadUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockDownloadUtilMockRecorder is the mock recorder for MockDownloadUtil.

--- a/pkg/utility/file_util_mock.go
+++ b/pkg/utility/file_util_mock.go
@@ -20,6 +20,7 @@ import (
 type MockFileUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockFileUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockFileUtilMockRecorder is the mock recorder for MockFileUtil.

--- a/pkg/utility/json_util_mock.go
+++ b/pkg/utility/json_util_mock.go
@@ -19,6 +19,7 @@ import (
 type MockJsonUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockJsonUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockJsonUtilMockRecorder is the mock recorder for MockJsonUtil.

--- a/pkg/utility/keyboard_util_mock.go
+++ b/pkg/utility/keyboard_util_mock.go
@@ -19,6 +19,7 @@ import (
 type MockKeyboardUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockKeyboardUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockKeyboardUtilMockRecorder is the mock recorder for MockKeyboardUtil.

--- a/pkg/utility/prompt_util_mock.go
+++ b/pkg/utility/prompt_util_mock.go
@@ -20,6 +20,7 @@ import (
 type MockPromptUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockPromptUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockPromptUtilMockRecorder is the mock recorder for MockPromptUtil.

--- a/pkg/utility/rand_util_mock.go
+++ b/pkg/utility/rand_util_mock.go
@@ -19,6 +19,7 @@ import (
 type MockRandUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockRandUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockRandUtilMockRecorder is the mock recorder for MockRandUtil.

--- a/pkg/utility/spinner_util_mock.go
+++ b/pkg/utility/spinner_util_mock.go
@@ -20,6 +20,7 @@ import (
 type MockSpinnerUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockSpinnerUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockSpinnerUtilMockRecorder is the mock recorder for MockSpinnerUtil.

--- a/pkg/utility/strings_util_mock.go
+++ b/pkg/utility/strings_util_mock.go
@@ -19,6 +19,7 @@ import (
 type MockStringsUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockStringsUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockStringsUtilMockRecorder is the mock recorder for MockStringsUtil.

--- a/pkg/utility/tablewriter_util_mock.go
+++ b/pkg/utility/tablewriter_util_mock.go
@@ -21,6 +21,7 @@ import (
 type MockTableWriterUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockTableWriterUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockTableWriterUtilMockRecorder is the mock recorder for MockTableWriterUtil.

--- a/pkg/utility/version_util_mock.go
+++ b/pkg/utility/version_util_mock.go
@@ -19,6 +19,7 @@ import (
 type MockVersionUtil struct {
 	ctrl     *gomock.Controller
 	recorder *MockVersionUtilMockRecorder
+	isgomock struct{}
 }
 
 // MockVersionUtilMockRecorder is the mock recorder for MockVersionUtil.


### PR DESCRIPTION
- add `isgomock struct{}` field to all mock structs generated by `gomock`
- this field serves as a type marker to identify mock implementations
- helps with type assertions and interface compliance verification
- applied consistently across all mock objects in the codebase