### PR TITLE
🐞fix:(tablewriter) fix table output indentation

### DIFF
--- a/pkg/utility/tablewriter_util.go
+++ b/pkg/utility/tablewriter_util.go
@@ -33,7 +33,6 @@ func (t *tableWriterUtil) GetNewDefaultTable(writer io.Writer) proxy.Table {
 		tablewriter.WithHeaderAutoFormat(tw.On),
 		tablewriter.WithHeaderAlignment(tw.AlignLeft),
 		tablewriter.WithRowAlignment(tw.AlignLeft),
-		tablewriter.WithPadding(tw.Padding{Left: "\t", Right: "", Overwrite: true}),
 		tablewriter.WithRendition(tw.Rendition{
 			Borders: tw.BorderNone,
 			Settings: tw.Settings{


### PR DESCRIPTION
- remove `WithPadding` with left tab that caused
  unwanted indentation in table output
- use default space padding instead

closes #146