### PR TITLE
🧹chore:(golangci-lint) bump version to v2.8

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(gh run view:*)",
-      "WebFetch(domain:goreleaser.com)",
-      "WebSearch"
-    ]
-  }
-}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: 1.25.x
-  GOLANGCI_LINT_VERSION: v2.0
+  GOLANGCI_LINT_VERSION: v2.8
 
 jobs:
   detect-modules:


### PR DESCRIPTION
- bump `golangci-lint` version from `v2.0` to `v2.8`
