### PR TITLE
🧹chore(deps): bump `go` to 1.26 and `golangci-lint` to v2.11

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,8 +8,8 @@ on:
       - "master"
 
 env:
-  GO_VERSION: 1.25.x
-  GOLANGCI_LINT_VERSION: v2.8
+  GO_VERSION: 1.26.x
+  GOLANGCI_LINT_VERSION: v2.11
 
 jobs:
   detect-modules:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.25.x
+          go-version: 1.26.x
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanosea/jrp/v2
 
-go 1.25.5
+go 1.26.1
 
 require (
 	github.com/briandowns/spinner v1.23.2

--- a/ops/docker/app/Dockerfile
+++ b/ops/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25
+FROM golang:1.26
 WORKDIR /jrp
 COPY . .
 RUN go mod download


### PR DESCRIPTION
- bump `go` version from 1.25.5 to 1.26.1 in `go.mod`
- bump `go` version from 1.25.x to 1.26.x in workflows and `Dockerfile`
- bump `golangci-lint` version from v2.8 to v2.11 in workflow

closes #161